### PR TITLE
feat: add func support to wrapperValue

### DIFF
--- a/values/value.go
+++ b/values/value.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // A Value is a Liquid runtime value.
@@ -28,7 +28,7 @@ type Value interface {
 
 // ValueOf returns a Value that wraps its argument.
 // If the argument is already a Value, it returns this.
-func ValueOf(value any) Value { //nolint: gocyclo
+func ValueOf(value any) Value { // nolint: gocyclo
 	// interned values
 	switch value {
 	case nil:
@@ -94,7 +94,14 @@ func (v valueEmbed) Test() bool                { return true }
 // A wrapperValue wraps a Go value.
 type wrapperValue struct{ value any }
 
-func (v wrapperValue) Equal(other Value) bool    { return Equal(v.value, other.Interface()) }
+func (v wrapperValue) Equal(other Value) bool {
+	fn, ok := other.Interface().(func(v interface{}) bool)
+	if ok {
+		return fn(v.Interface())
+	}
+
+	return Equal(v.value, other.Interface())
+}
 func (v wrapperValue) Less(other Value) bool     { return Less(v.value, other.Interface()) }
 func (v wrapperValue) IndexValue(Value) Value    { return nilValue }
 func (v wrapperValue) Contains(Value) bool       { return false }

--- a/values/value_test.go
+++ b/values/value_test.go
@@ -3,7 +3,7 @@ package values
 import (
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +23,18 @@ func TestValue_Equal(t *testing.T) {
 	iv := ValueOf(123)
 	require.True(t, iv.Equal(ValueOf(123)))
 	require.True(t, iv.Equal(ValueOf(123.0)))
+}
+
+func TestValue_Func(t *testing.T) {
+	iv := ValueOf("empty")
+
+	require.True(t, iv.Equal(ValueOf(func(val interface{}) bool {
+		return true
+	})))
+
+	require.False(t, iv.Equal(ValueOf(func(val interface{}) bool {
+		return false
+	})))
 }
 
 func TestValue_Less(t *testing.T) {


### PR DESCRIPTION
NES-0

This change is coming from an old issue where we found that the engine is missing the `empty` keyword which is supposed to work on strings, lists, etc.

A way to tackle that is by extending the `Equal()` function of a `wrapperValue{}` which then allows us to write functions like so:

```go
import "github.com/messagebird-dev/liquid/values"

bindings := map[string]any{
  "empty": func(value any) bool {
    return values.IsEmpty(value)
  }
}
```