### PR TITLE
fix: size property val

### DIFF
--- a/values/value.go
+++ b/values/value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode/utf8"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -226,7 +227,7 @@ func (sv stringValue) Contains(substr Value) bool {
 
 func (sv stringValue) PropertyValue(iv Value) Value {
 	if iv.Interface() == sizeKey {
-		return ValueOf(len(sv.value.(string)))
+		return ValueOf(utf8.RuneCountInString(sv.value.(string)))
 	}
 	return nilValue
 }


### PR DESCRIPTION
Bug, the .size property on strings is measuring the bytes not the characters. This is v important for WU because they like to do conditionals based on SMS message size.

Note: I do not need to fix the `| size` filter, [that doesn't suffer from this bug](https://github.com/messagebird-dev/liquid/blob/fix/size-property-val/values/arrays.go#L20).